### PR TITLE
Permitir la Subida de Archivos de el Mismo nombre

### DIFF
--- a/server/src/routes/upload.js
+++ b/server/src/routes/upload.js
@@ -2,8 +2,35 @@ const router = require('express').Router();
 const fileUpload = require('express-fileupload');
 const processPath = require('../lib/path');
 const moveFile = require('../lib/mv');
+const fs = require("fs");
 
 router.use(fileUpload());
+
+async function searchFile(path, name) {
+  try {
+    const dirPath = path
+    const dir = await fs.promises.opendir(dirPath.absolutePath);
+    const content = [];
+    var save = true;
+    for await (const dirent of dir) {   
+    if (!dirent.isDirectory()) {
+        content.push(dirent.name);
+      }
+    }
+
+   
+   content.forEach(element => {
+    if (element == name) {
+      save = false;
+    }
+   });
+   return save;
+  }
+  catch (err) {
+    console.log(err);
+    return err;
+  }
+}
 
 router.post('/:path?', async (req, res, next) => {
   if (!req.files) {
@@ -21,7 +48,24 @@ router.post('/:path?', async (req, res, next) => {
 
   try {
     for (const file of files) {
+      const resulNameFile = await searchFile(dirPath, file.name)
+	       if (resulNameFile) {
       await moveFile(file, dirPath.absolutePath);
+    } else {
+      const tmpfile = file;
+      var name = tmpfile.name.substr(0, (tmpfile.name.lastIndexOf(".")));
+      var extension = tmpfile.name.substr(tmpfile.name.lastIndexOf("."));
+      tmpfile.name = name + "(1)" + extension;
+      var resulNameTmpFile = await searchFile(dirPath, tmpfile.name)
+      let i = 1;
+      while(!resulNameTmpFile){
+         tmpfile.name = name + "(" + i + ")" + extension;
+         resulNameTmpFile = await searchFile(dirPath, tmpfile.name)
+         i++
+      }
+      await moveFile(tmpfile, dirPath.absolutePath);
+    }
+
     }
   } catch (err) {
     return next(err);


### PR DESCRIPTION
Este PR añade la posibilidad de subir archivos que se llamen de la misma manera sin sobreescribirse.

Modifica el server/src/routes/upload.js añadiendo una funcion searchFile que le pasas el path y el nombre y busca si existe otro con el mismo nombre en el path especificado.

Al recibir una peticion comprueba si existe otro archivo del mismo nombre, si lo hay prueba con un while (respetando la extension del archivo) hasta encontrar un archivo con un numero empezando por 1.


Testeado en node v14.7.0